### PR TITLE
feat: legal pages

### DIFF
--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+import EuphrosyneHeader from "@/components/EuphrosyneHeader";
+import { Footer } from "@/components/Footer";
+import { Lang } from "@/i18n";
+
+import { Providers } from "./providers";
+import {
+  DsfrHead,
+  getHtmlAttributes,
+} from "../dsfr-bootstrap/server-only-index";
+
+import "./globals.css";
+
+export interface ILayoutParams {
+  lang: Lang;
+}
+
+export default function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: ILayoutParams;
+}) {
+  const { lang } = params;
+  return (
+    <html {...getHtmlAttributes({ lang })}>
+      <head>
+        <DsfrHead />
+      </head>
+      <body>
+        <Providers lang={lang}>
+          <EuphrosyneHeader currentLang={lang} />
+          {children}
+          <Footer currentLang={lang} />
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,26 +1,14 @@
 import { Metadata } from "next";
 import React from "react";
 
-import EuphrosyneHeader from "@/components/EuphrosyneHeader";
-import { Footer } from "@/components/Footer";
-import { Lang } from "@/i18n";
-
-import {
-  DsfrHead,
-  getHtmlAttributes,
-} from "../../dsfr-bootstrap/server-only-index";
+import Layout, { ILayoutParams } from "../Layout";
 import "../globals.css";
-import { Providers } from "../providers";
 import { getTranslations } from "./dictionaries";
-
-interface IRootLayoutParams {
-  lang: Lang;
-}
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<IRootLayoutParams>;
+  params: Promise<ILayoutParams>;
 }): Promise<Metadata> {
   // read route params
   const { lang } = await params;
@@ -36,21 +24,8 @@ export default async function RootLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: Promise<IRootLayoutParams>;
+  params: Promise<ILayoutParams>;
 }) {
-  const { lang } = await params;
-  return (
-    <html {...getHtmlAttributes({ lang })}>
-      <head>
-        <DsfrHead />
-      </head>
-      <body>
-        <Providers lang={lang}>
-          <EuphrosyneHeader currentLang={lang} />
-          {children}
-          <Footer currentLang={lang} />
-        </Providers>
-      </body>
-    </html>
-  );
+  const awaitedParams = await params;
+  return <Layout params={awaitedParams}>{children}</Layout>;
 }

--- a/src/app/en/layout.tsx
+++ b/src/app/en/layout.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+import React from "react";
+
+import { getTranslations } from "../[lang]/dictionaries";
+import Layout from "../Layout";
+import "../globals.css";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const translations = getTranslations("en");
+
+  return {
+    title: translations.base.siteTitle,
+  };
+}
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <Layout params={{ lang: "en" }}>{children}</Layout>;
+}

--- a/src/app/en/legal/gcu/page.tsx
+++ b/src/app/en/legal/gcu/page.tsx
@@ -1,0 +1,63 @@
+import { Metadata } from "next";
+
+import { BaseSection } from "@/components/BaseSection";
+
+export const metadata: Metadata = {
+  title: "Terms of Use",
+};
+
+export default function GCUPage() {
+  return (
+    <BaseSection>
+      <h1 className="text-3xl font-bold mb-8">Terms of Use</h1>
+      <div className="prose prose-lg max-w-none">
+        <h3>Terms of Use</h3>
+        <p>
+          By accessing and using this site, you agree to be bound by these terms
+          of use. If you do not agree to these terms, please do not use this
+          site.
+        </p>
+
+        <h3>Site Usage</h3>
+        <p>
+          This site is intended to provide information about the Euphrosyne
+          project. You agree to use this site only for lawful purposes and in a
+          way that does not infringe the rights of others or restrict or inhibit
+          anyone else&apos;s use and enjoyment of the site.
+        </p>
+
+        <h3>Intellectual Property</h3>
+        <p>
+          All content on this site, including but not limited to text, graphics,
+          logos, icons, images, audio clips, digital downloads, and data
+          compilations, is the property of L&apos;Atelier Numérique or its
+          content suppliers and is protected by French and international
+          copyright laws.
+        </p>
+
+        <h3>Limitation of Liability</h3>
+        <p>
+          L&apos;Atelier Numérique will not be liable for any damages of any
+          kind arising from the use or inability to use this site, including but
+          not limited to direct, indirect, incidental, consequential, or
+          punitive damages.
+        </p>
+
+        <h3>Changes to Terms</h3>
+        <p>
+          L&apos;Atelier Numérique reserves the right to modify these terms of
+          use at any time. Changes take effect upon posting to the site. Your
+          continued use of the site after changes are posted constitutes your
+          acceptance of the modified terms.
+        </p>
+
+        <h3>Governing Law</h3>
+        <p>
+          These terms of use are governed by and construed in accordance with
+          French law. Any dispute relating to these terms shall be subject to
+          the exclusive jurisdiction of the French courts.
+        </p>
+      </div>
+    </BaseSection>
+  );
+}

--- a/src/app/en/legal/legal-notice/page.tsx
+++ b/src/app/en/legal/legal-notice/page.tsx
@@ -1,0 +1,29 @@
+import { Metadata } from "next";
+
+import { BaseSection } from "@/components/BaseSection";
+
+export const metadata: Metadata = {
+  title: "Legal Notice",
+};
+
+export default function LegalNoticePage() {
+  return (
+    <BaseSection>
+      <h1 className="text-3xl font-bold mb-8">Legal Notice</h1>
+      <div className="prose prose-lg max-w-none">
+        <h3>Publisher</h3>
+        <p>
+          <a href="https://beta.gouv.fr/startups/?incubateur=culture">
+            L&apos;atelier Numérique
+          </a>{" "}
+          of the Ministry of Culture (
+          <a href="https://www.culture.gouv.fr">site</a>). 182 rue Saint-Honoré,
+          75001 Paris.
+        </p>
+
+        <h3>Hosting</h3>
+        <p>Scalingo. 15 avenue du Rhin, 67100 Strasbourg, France.</p>
+      </div>
+    </BaseSection>
+  );
+}

--- a/src/app/en/legal/personal-data/page.tsx
+++ b/src/app/en/legal/personal-data/page.tsx
@@ -1,0 +1,54 @@
+import { BaseSection } from "@/components/BaseSection";
+import { StartDsfrOnHydration } from "@/dsfr-bootstrap";
+
+export default function PersonalDataPage() {
+  return (
+    <>
+      <StartDsfrOnHydration />
+      <BaseSection>
+        <h1>Personal data and cookies</h1>
+
+        <h2>Cookies placed and opt-out</h2>
+        <p>
+          This site places a small text file (a &ldquo;cookie&rdquo;) on your
+          computer when you visit it. This allows us to measure the number of
+          visits and understand which pages are most viewed.
+        </p>
+
+        <h2>This site does not display a cookie consent banner, why?</h2>
+        <p>
+          That&apos;s right, you didn&apos;t have to click on a block that
+          covers half the page to say that you agree with the placement of
+          cookies — even if you don&apos;t know what that means!
+        </p>
+        <p>
+          Nothing exceptional, no special privilege related to a .gouv.fr. We
+          simply respect the law, which says that some audience tracking tools,
+          correctly configured to respect privacy, are exempt from prior
+          authorization.
+        </p>
+        <p>
+          For this, we use Matomo, a free tool, set up to comply with the
+          &ldquo;Cookies&rdquo; recommendation of the CNIL. This means that your
+          IP address, for example, is anonymized before being recorded. It is
+          therefore impossible to associate your visits to this site with your
+          person.
+        </p>
+
+        <h2>I contribute to enriching your data, can I access it?</h2>
+        <p>
+          Of course! Usage statistics for the majority of our products,
+          including beta.gouv.fr, are freely accessible on{" "}
+          <a
+            href="https://stats.data.gouv.fr"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            stats.data.gouv.fr
+          </a>
+          .
+        </p>
+      </BaseSection>
+    </>
+  );
+}

--- a/src/app/fr/layout.tsx
+++ b/src/app/fr/layout.tsx
@@ -6,7 +6,7 @@ import Layout from "../Layout";
 import "../globals.css";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const translations = getTranslations("en");
+  const translations = getTranslations("fr");
 
   return {
     title: translations.base.siteTitle,

--- a/src/app/fr/layout.tsx
+++ b/src/app/fr/layout.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+import React from "react";
+
+import { getTranslations } from "../[lang]/dictionaries";
+import Layout from "../Layout";
+import "../globals.css";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const translations = getTranslations("en");
+
+  return {
+    title: translations.base.siteTitle,
+  };
+}
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <Layout params={{ lang: "fr" }}>{children}</Layout>;
+}

--- a/src/app/fr/legal/cgu/page.tsx
+++ b/src/app/fr/legal/cgu/page.tsx
@@ -1,0 +1,67 @@
+import { Metadata } from "next";
+
+import { BaseSection } from "@/components/BaseSection";
+
+export const metadata: Metadata = {
+  title: "Conditions d'utilisation",
+};
+
+export default function CGUPage() {
+  return (
+    <BaseSection>
+      <h1 className="text-3xl font-bold mb-8">Conditions d&apos;utilisation</h1>
+      <div className="prose prose-lg max-w-none">
+        <h3>Conditions d&apos;utilisation</h3>
+        <p>
+          En accédant et en utilisant ce site, vous acceptez d&apos;être lié par
+          les présentes conditions d&apos;utilisation. Si vous n&apos;acceptez
+          pas ces conditions, veuillez ne pas utiliser ce site.
+        </p>
+
+        <h3>Utilisation du site</h3>
+        <p>
+          Ce site est destiné à fournir des informations sur le projet
+          Euphrosyne. Vous acceptez d&apos;utiliser ce site uniquement à des
+          fins légales et d&apos;une manière qui ne porte pas atteinte aux
+          droits des autres ou qui ne restreint ou n&apos;inhibe pas
+          l&apos;utilisation et la jouissance du site par quiconque.
+        </p>
+
+        <h3>Propriété intellectuelle</h3>
+        <p>
+          Tout le contenu présent sur ce site, y compris mais sans s&apos;y
+          limiter, le texte, les graphiques, les logos, les icônes, les images,
+          les clips audio, les téléchargements numériques et les compilations de
+          données, est la propriété de L&apos;Atelier Numérique ou de ses
+          fournisseurs de contenu et est protégé par les lois françaises et
+          internationales sur le droit d&apos;auteur. le droit d&apos;auteur.
+        </p>
+
+        <h3>Limitation de responsabilité</h3>
+        <p>
+          L&apos;Atelier Numérique ne sera pas responsable des dommages de
+          quelque nature que ce soit résultant de l&apos;utilisation ou de
+          l&apos;impossibilité d&apos;utiliser ce site, y compris, mais sans
+          s&apos;y limiter, les dommages directs, indirects, accessoires,
+          consécutifs ou punitifs.
+        </p>
+
+        <h3>Modifications des conditions</h3>
+        <p>
+          L&apos;Atelier Numérique se réserve le droit de modifier ces
+          conditions d&apos;utilisation à tout moment. Les modifications entrent
+          en vigueur dès leur publication sur le site. Votre utilisation
+          continue du site après la publication des modifications constitue
+          votre acceptation des conditions modifiées.
+        </p>
+
+        <h3>Droit applicable</h3>
+        <p>
+          Ces conditions d&apos;utilisation sont régies et interprétées
+          conformément aux lois françaises. Tout litige relatif à ces conditions
+          sera soumis à la juridiction exclusive des tribunaux français.
+        </p>
+      </div>
+    </BaseSection>
+  );
+}

--- a/src/app/fr/legal/donnees-personnelles/page.tsx
+++ b/src/app/fr/legal/donnees-personnelles/page.tsx
@@ -1,0 +1,59 @@
+import { BaseSection } from "@/components/BaseSection";
+import { StartDsfrOnHydration } from "@/dsfr-bootstrap";
+
+export default function PersonalDataPage() {
+  return (
+    <>
+      <StartDsfrOnHydration />
+      <BaseSection>
+        <h1>Données personnelles et cookies</h1>
+
+        <h2>Cookies déposés et opt-out</h2>
+        <p>
+          Ce site dépose un petit fichier texte (un &laquo; cookie &raquo;) sur
+          votre ordinateur lorsque vous le consultez. Cela nous permet de
+          mesurer le nombre de visites et de comprendre quelles sont les pages
+          les plus consultées.
+        </p>
+
+        <h2>
+          Ce site n&apos;affiche pas de bannière de consentement aux cookies,
+          pourquoi ?
+        </h2>
+        <p>
+          C&apos;est vrai, vous n&apos;avez pas eu à cliquer sur un bloc qui
+          recouvre la moitié de la page pour dire que vous êtes d&apos;accord
+          avec le dépôt de cookies — même si vous ne savez pas ce que ça veut
+          dire !
+        </p>
+        <p>
+          Rien d&apos;exceptionnel, pas de passe-droit lié à un .gouv.fr. Nous
+          respectons simplement la loi, qui dit que certains outils de suivi
+          d&apos;audience, correctement configurés pour respecter la vie privée,
+          sont exemptés d&apos;autorisation préalable.
+        </p>
+        <p>
+          Nous utilisons pour cela Matomo, un outil libre, paramétré pour être
+          en conformité avec la recommandation &laquo; Cookies &raquo; de la
+          CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée
+          avant d&apos;être enregistrée. Il est donc impossible d&apos;associer
+          vos visites sur ce site à votre personne.
+        </p>
+
+        <h2>Je contribue à enrichir vos données, puis-je y accéder ?</h2>
+        <p>
+          Bien sûr ! Les statistiques d&apos;usage de la majorité de nos
+          produits, dont beta.gouv.fr, sont disponibles en accès libre sur{" "}
+          <a
+            href="https://stats.data.gouv.fr"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            stats.data.gouv.fr
+          </a>
+          .
+        </p>
+      </BaseSection>
+    </>
+  );
+}

--- a/src/app/fr/legal/mentions-legales/page.tsx
+++ b/src/app/fr/legal/mentions-legales/page.tsx
@@ -1,0 +1,29 @@
+import { Metadata } from "next";
+
+import { BaseSection } from "@/components/BaseSection";
+
+export const metadata: Metadata = {
+  title: "Mentions légales",
+};
+
+export default function MentionsLegalesPage() {
+  return (
+    <BaseSection>
+      <h1 className="text-3xl font-bold mb-8">Mentions légales</h1>
+      <div className="prose prose-lg max-w-none">
+        <h3>Éditeur</h3>
+        <p>
+          <a href="https://beta.gouv.fr/startups/?incubateur=culture">
+            L&apos;atelier Numérique
+          </a>{" "}
+          du Ministere de la Culture (
+          <a href="https://www.culture.gouv.fr">site</a>). 182 rue Saint-Honoré,
+          75001 Paris.
+        </p>
+
+        <h3>Hébergeur</h3>
+        <p>Scalingo. 15 avenue du Rhin, 67100 Strasbourg, France.</p>
+      </div>
+    </BaseSection>
+  );
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -307,16 +307,16 @@ const footerContent = {
   homeLinkTitle: `Home - ${siteTitle}`,
   bottomItems: [
     {
-      href: "/legal/donnees-personnelles",
+      href: "/en/legal/personal-data",
       text: "Personal data and Cookies",
     },
     {
-      href: "/legal/cgu",
+      href: "/en/legal/gcu",
       text: "Terms of Use",
     },
   ],
   termsLink: {
-    href: "/legal/mentions-legales",
+    href: "/en/legal/legal-notice",
   },
 };
 

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -310,16 +310,16 @@ export const footerContent = {
   homeLinkTitle: `Accueil - ${siteTitle}`,
   bottomItems: [
     {
-      href: "/legal/donnees-personnelles",
+      href: "/fr/legal/donnees-personnelles",
       text: "Données personnelles et Cookies",
     },
     {
-      href: "/legal/cgu",
+      href: "/fr/legal/cgu",
       text: "Conditions générales d'utilisation",
     },
   ],
   termsLink: {
-    href: "/legal/mentions-legales",
+    href: "/fr/legal/mentions-legales",
   },
 };
 


### PR DESCRIPTION
- Added a new Layout component to standardize the structure of pages.
- Updated language-specific layout files to utilize the new Layout component.
- Created legal pages in English and French, including Terms of Use, Legal Notice, and Personal Data pages.
- Updated footer links to reflect new routing for legal documents.